### PR TITLE
next() can hang indefinitely if the Task is already cancelled.

### DIFF
--- a/Sources/Operators/AsyncSwitchToLatestSequence.swift
+++ b/Sources/Operators/AsyncSwitchToLatestSequence.swift
@@ -221,8 +221,11 @@ where Base.Element: AsyncSequence, Base: Sendable, Base.Element.Element: Sendabl
       guard !Task.isCancelled else { return nil }
       self.startBase()
 
-      return try await withTaskCancellationHandler { [baseTask] in
+      return try await withTaskCancellationHandler { [baseTask, state] in
         baseTask?.cancel()
+        state.withCriticalRegion {
+          $0.childTask?.cancel()
+        }
       } operation: {
         while true {
           let childTask = await withUnsafeContinuation { [state] (continuation: UnsafeContinuation<Task<ChildValue?, Never>?, Never>) in

--- a/Sources/Operators/AsyncSwitchToLatestSequence.swift
+++ b/Sources/Operators/AsyncSwitchToLatestSequence.swift
@@ -218,6 +218,7 @@ where Base.Element: AsyncSequence, Base: Sendable, Base.Element.Element: Sendabl
     }
 
     public mutating func next() async rethrows -> Element? {
+      guard !Task.isCancelled else { return nil }
       self.startBase()
 
       return try await withTaskCancellationHandler { [baseTask] in


### PR DESCRIPTION
~The unstructured child task used to track iterators is not cancelled when the parent task is cancelled.~

~An explicit cancellation handler is required.~

Updated for mainline branch changes.  In some situations I observe that the `next()` never returns if the calling task is already cancelled.  This fix is required.