### PR TITLE
multicast: dont cancel upstream sequence when client is cancelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+**v0.5.2 - Oxygen:**
+
+This version is a bug fix version.
+
+- Multicast: don't cancel the upstream sequence when a client is cancelled
+
 **v0.5.1 - Nitrogen:**
 
 This version removes compilation unsafe flags

--- a/Sources/AsyncSubjects/AsyncReplaySubject.swift
+++ b/Sources/AsyncSubjects/AsyncReplaySubject.swift
@@ -46,33 +46,29 @@ public final class AsyncReplaySubject<Element>: AsyncSubject where Element: Send
   /// Sends a value to all consumers
   /// - Parameter element: the value to send
   public func send(_ element: Element) {
-    let channels = self.state.withCriticalRegion { state -> [AsyncBufferedChannel<Element>] in
+    self.state.withCriticalRegion { state in
       if state.buffer.count >= state.bufferSize && !state.buffer.isEmpty {
         state.buffer.removeFirst()
       }
       state.buffer.append(element)
-      return Array(state.channels.values)
-    }
-
-    for channel in channels {
-      channel.send(element)
+      for channel in state.channels.values {
+        channel.send(element)
+      }
     }
   }
 
   /// Finishes the subject with a normal ending.
   /// - Parameter termination: The termination to finish the subject.
   public func send(_ termination: Termination<Failure>) {
-    let channels = self.state.withCriticalRegion { state -> [AsyncBufferedChannel<Element>] in
+    self.state.withCriticalRegion { state in
       state.terminalState = termination
       let channels = Array(state.channels.values)
       state.channels.removeAll()
       state.buffer.removeAll()
       state.bufferSize = 0
-      return channels
-    }
-
-    for channel in channels {
-      channel.finish()
+      for channel in channels {
+        channel.finish()
+      }
     }
   }
 
@@ -124,10 +120,10 @@ public final class AsyncReplaySubject<Element>: AsyncSubject where Element: Send
     }
 
     public mutating func next() async -> Element? {
-      await withTaskCancellationHandler { [unregister] in
-        unregister()
-      } operation: {
+      await withTaskCancellationHandler {
         await self.iterator.next()
+      } onCancel: { [unregister] in
+        unregister()
       }
     }
   }

--- a/Sources/AsyncSubjects/AsyncThrowingCurrentValueSubject.swift
+++ b/Sources/AsyncSubjects/AsyncThrowingCurrentValueSubject.swift
@@ -67,32 +67,28 @@ public final class AsyncThrowingCurrentValueSubject<Element, Failure: Error>: As
   /// Sends a value to all consumers
   /// - Parameter element: the value to send
   public func send(_ element: Element) {
-    let channels = self.state.withCriticalRegion { state -> [AsyncThrowingBufferedChannel<Element, Error>] in
+    self.state.withCriticalRegion { state in
       state.current = element
-      return Array(state.channels.values)
-    }
-
-    for channel in channels {
-      channel.send(element)
+      for channel in state.channels.values {
+        channel.send(element)
+      }
     }
   }
 
   /// Finishes the subject with either a normal ending or an error.
   /// - Parameter termination: The termination to finish the subject.
   public func send(_ termination: Termination<Failure>) {
-    let channels = self.state.withCriticalRegion { state -> [AsyncThrowingBufferedChannel<Element, Error>] in
+    self.state.withCriticalRegion { state in
       state.terminalState = termination
       let channels = Array(state.channels.values)
       state.channels.removeAll()
-      return channels
-    }
-
-    for channel in channels {
-      switch termination {
-        case .finished:
-          channel.finish()
-        case .failure(let error):
-          channel.fail(error)
+      for channel in channels {
+        switch termination {
+          case .finished:
+            channel.finish()
+          case .failure(let error):
+            channel.fail(error)
+        }
       }
     }
   }
@@ -149,10 +145,10 @@ public final class AsyncThrowingCurrentValueSubject<Element, Failure: Error>: As
     }
 
     public mutating func next() async throws -> Element? {
-      try await withTaskCancellationHandler { [unregister] in
-        unregister()
-      } operation: {
+      try await withTaskCancellationHandler {
         try await self.iterator.next()
+      } onCancel: { [unregister] in
+        unregister()
       }
     }
   }

--- a/Tests/Operators/AsyncMulticastSequenceTests.swift
+++ b/Tests/Operators/AsyncMulticastSequenceTests.swift
@@ -8,27 +8,6 @@
 import AsyncExtensions
 import XCTest
 
-private struct SpyAsyncSequenceForOnNextCall<Element>: AsyncSequence {
-  typealias Element = Element
-  typealias AsyncIterator = Iterator
-  
-  let onNext: () -> Void
-  
-  func makeAsyncIterator() -> AsyncIterator {
-    Iterator(onNext: self.onNext)
-  }
-  
-  struct Iterator: AsyncIteratorProtocol {
-    let onNext: () -> Void
-    
-    func next() async throws -> Element? {
-      self.onNext()
-      try await Task.sleep(nanoseconds: 100_000_000_000)
-      return nil
-    }
-  }
-}
-
 private class SpyAsyncSequenceForNumberOfIterators<Element>: AsyncSequence {
   typealias Element = Element
   typealias AsyncIterator = Iterator
@@ -176,46 +155,5 @@ final class AsyncMulticastSequenceTests: XCTestCase {
       XCTAssertEqual(receivedElement, [1])
       XCTAssertEqual(error as? MockError, expectedError)
     }
-  }
-  
-  func test_multicast_finishes_when_task_is_cancelled() {
-    let taskHasFinishedExpectation = expectation(description: "Task has finished")
-    
-    let stream = AsyncThrowingPassthroughSubject<Int, Error>()
-    let sut = AsyncLazySequence<[Int]>([1, 2, 3, 4, 5])
-      .multicast(stream)
-      .autoconnect()
-    
-    Task {
-      for try await _ in sut {}
-      taskHasFinishedExpectation.fulfill()
-    }.cancel()
-    
-    wait(for: [taskHasFinishedExpectation], timeout: 1)
-  }
-  
-  func test_multicast_finishes_when_task_is_cancelled_while_waiting_for_next() {
-    let canCancelExpectation = expectation(description: "the task can be cancelled")
-    let taskHasFinishedExpectation = expectation(description: "Task has finished")
-    
-    let spyAsyncSequence = SpyAsyncSequenceForOnNextCall<Int> {
-      canCancelExpectation.fulfill()
-    }
-    
-    let stream = AsyncThrowingPassthroughSubject<Int, Error>()
-    let sut = spyAsyncSequence
-      .multicast(stream)
-      .autoconnect()
-    
-    let task = Task {
-      for try await _ in sut {}
-      taskHasFinishedExpectation.fulfill()
-    }
-    
-    wait(for: [canCancelExpectation], timeout: 1)
-    
-    task.cancel()
-    
-    wait(for: [taskHasFinishedExpectation], timeout: 1)
   }
 }

--- a/Tests/Operators/AsyncSequence+ShareTests.swift
+++ b/Tests/Operators/AsyncSequence+ShareTests.swift
@@ -40,15 +40,15 @@ private struct LongAsyncSequence<Element>: AsyncSequence, AsyncIteratorProtocol 
   }
   
   mutating func next() async throws -> Element? {
-    return try await withTaskCancellationHandler { [onCancel] in
-      onCancel()
-    } operation: {
+    return try await withTaskCancellationHandler {
       try await Task.sleep(nanoseconds: self.interval.nanoseconds)
       self.currentIndex += 1
       if self.currentIndex == self.failAt {
         throw MockError(code: 0)
       }
       return self.elements.next()
+    } onCancel: {[onCancel] in
+      onCancel()
     }
   }
   


### PR DESCRIPTION
## Description
This PR makes the `multicast` operator iterate over the upstream sequence in a dedicated task so that collaborative cancellation does not apply. In a multicast world, the upstream sequence should continue to be iterated by new Tasks when one of its client is cancelled.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] this PR is based on the **main** branch and is up-to-date, if not please rebase your branch on the top of **main**
- [x] the commits inside this PR have explicit commit messages
- [x] unit tests cover the new feature or the bug fix
- [x] the CHANGELOG is up-to-date
