### PR TITLE
Fix Xcode 16 build failure caused by AsyncSubject

### DIFF
--- a/Sources/AsyncSubjects/AsyncSubject.swift
+++ b/Sources/AsyncSubjects/AsyncSubject.swift
@@ -6,12 +6,17 @@
 //
 
 #if swift(>=5.7)
-public protocol AsyncSubject<Element, Failure>: AnyObject, AsyncSequence, Sendable where AsyncIterator: AsyncSubjectIterator {
-  associatedtype Failure: Error
-
-  func send(_ element: Element)
-  func send(_ termination: Termination<Failure>)
+public protocol AsyncSubjectable<Element>: AnyObject, AsyncSequence, Sendable where AsyncIterator: AsyncSubjectIterator {
+    func send(_ element: Element)
 }
+
+public protocol AsyncSubjectTerminable {
+    associatedtype Failure: Error
+
+    func send(_ termination: Termination<Failure>)
+}
+
+public typealias AsyncSubject = AsyncSubjectable & AsyncSubjectTerminable
 #else
 public protocol AsyncSubject: AnyObject, AsyncSequence, Sendable where AsyncIterator: AsyncSubjectIterator {
   associatedtype Failure: Error


### PR DESCRIPTION
Fix AsyncSubject's Failure type conflincting with Apple addition to AsyncSequence starting from Xcode 16 (iOS 18, MacOS 15, Vision OS 2, etc.)

## Description
For more information on what caused the issue, see [this discussion](https://github.com/sideeffect-io/AsyncExtensions/issues/41).

Fixed by:
- Splitting `AsyncSubject` procotol into two protocols:
    - AsyncSubjectable, meant to define the `send(element:)` method and dependance to `AsyncSequence` and other protocols
    - AsyncSubjectTerminable, meant to define both the AsyncSubject's `Failure` type and the `send(termination:)` method
- Making AsyncSubject a `typealias` to a conformance of both of these new protocols

This results in the compiler either:
- using the `AsyncSubjectTerminable`'s Failure type on its own when `AsyncSequence` doesn't defines it (up until Xcode 16)
- allowing both `AsyncSubjectTerminable` and `AsyncSequence`'s Failure type to be the same type when `AsyncSequence` does define its own Failure type (starting from Xcode 16)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] this PR is based on the **main** branch and is up-to-date, if not please rebase your branch on the top of **main**
- [x] the commits inside this PR have explicit commit messages
- [x] unit tests cover the new feature or the bug fix
- [ ] the feature is documented in the README.md if it makes sense
- [ ] the CHANGELOG is up-to-date
