### PR TITLE
Conform `AnyAsyncSequence` to `Sendable`

### DIFF
--- a/Sources/Operators/AsyncSequence+EraseToAnyAsyncSequence.swift
+++ b/Sources/Operators/AsyncSequence+EraseToAnyAsyncSequence.swift
@@ -42,3 +42,5 @@ public struct AnyAsyncIterator<Element>: AsyncIteratorProtocol {
     try await self.nextClosure()
   }
 }
+
+extension AnyAsyncSequence: Sendable {}


### PR DESCRIPTION
## Description

I defined an `AsyncPassthroughSubject` as a private property and exposed it as an `AnyAsyncSequence` by performing type erasure with `.eraseToAnyAsyncSequence()`. For example:

```swift
actor SampleActor {
    private let numbersSubject = AsyncPassthroughSubject<Int>()
    public var numbers: AnyAsyncSequence<Int> {
        self.numbersSubject.eraseToAnyAsyncSequence()
    }
    ...
}
```

I then use this actor to retrieve values from `numbers` like so:

```swift
let sampleActor = SampleActor()

for try await number in await sampleActor.numbers {
    ...
}
```

However, in my project I am using Swift 6, where the compiler enforces Sendable checking. Since `AnyAsyncSequence` does not conform to `Sendable`, the following error occurs:

```
Non-sendable type 'AnyAsyncSequence<Int>' in implicitly asynchronous access to actor-isolated property 'numbers' cannot cross actor boundary
```

Although it's possible to work around this issue on the user side (for example, by adding `extension AnyAsyncSequence: @unchecked Sendable {}` or by marking the property as `public nonisolated var numbers: AnyAsyncSequence<Int>`), I would like to resolve this problem within the library itself.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] this PR is based on the **main** branch and is up-to-date, if not please rebase your branch on the top of **main**
- [x] the commits inside this PR have explicit commit messages
- [x] unit tests cover the new feature or the bug fix
- [x] the feature is documented in the README.md if it makes sense
- [ ] the CHANGELOG is up-to-date
